### PR TITLE
Removing relative link from includes in gingonic test

### DIFF
--- a/gingonic/gingonic_test.go
+++ b/gingonic/gingonic_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	. "../gingonic"
+	. "github.com/Fatsoma/api2go-adapter/gingonic"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go"
 	"github.com/manyminds/api2go/examples/model"


### PR DESCRIPTION
This allows us to migrate to dep from glide.